### PR TITLE
Upgrade to latest heapless

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,5 @@ categories = [
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-heapless = "0.5.5"
+heapless = "0.7.0"
 embedded-hal = "0.2.4"

--- a/README.md
+++ b/README.md
@@ -10,8 +10,9 @@ encoded as a u32.
 ```rust
 use blinq::{Pattern, Blinq, patterns, consts};
 
-// Create a blink queue with room for 8 patterns, that is active-low
-let mut blinq: Blinq<consts::U8, FakeGpio> = Blinq::new(gpio, true);
+// Create a blink queue with room for 8 patterns (note: the capacity must be 1 higher
+// then the amount of patterns you wish to store), that is active-low
+let mut blinq: Blinq<9, FakeGpio> = Blinq::new(gpio, true);
 
 // Insert "HELLO." in morse code
 

--- a/examples/nrf52-blink/src/main.rs
+++ b/examples/nrf52-blink/src/main.rs
@@ -7,7 +7,7 @@
 #![no_std]
 #![no_main]
 
-use blinq::{consts, patterns, Blinq};
+use blinq::{patterns, Blinq};
 use cortex_m_rt::entry;
 use embedded_hal::blocking::delay::DelayMs;
 use nrf52840_hal::{
@@ -32,8 +32,8 @@ fn main() -> ! {
     let led1 = gpios.p0_13.into_push_pull_output(Level::High);
     let led2 = gpios.p0_14.into_push_pull_output(Level::High);
 
-    let mut blinq_sos: Blinq<consts::U1, P0_13<Output<PushPull>>> = Blinq::new(led1, true);
-    let mut blinq_hello: Blinq<consts::U6, P0_14<Output<PushPull>>> = Blinq::new(led2, true);
+    let mut blinq_sos: Blinq<P0_13<Output<PushPull>>, 2> = Blinq::new(led1, true);
+    let mut blinq_hello: Blinq<P0_14<Output<PushPull>>, 7> = Blinq::new(led2, true);
 
     loop {
         if blinq_sos.idle() && blinq_hello.idle() {


### PR DESCRIPTION
See title.

This change is breaking: `heapless` 0.7 uses const generics instead of typenum. Additionally, `heapless` Queues store `N - 1` elements, so the element count for blinq queues has to be increased by 1 for now, as const generic arithmetic is not supported yet. I have added clarifying comments regarding that to the usage examples.

It could make sense to wait with this upgrade until full-fledged const generics are released, but I figured I'd put up this PR for good measure since it is a good feature to have.