### PR TITLE
README: Fix type argument order

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ use blinq::{Pattern, Blinq, patterns, consts};
 
 // Create a blink queue with room for 8 patterns (note: the capacity must be 1 higher
 // then the amount of patterns you wish to store), that is active-low
-let mut blinq: Blinq<9, FakeGpio> = Blinq::new(gpio, true);
+let mut blinq: Blinq<FakeGpio, 9> = Blinq::new(gpio, true);
 
 // Insert "HELLO." in morse code
 


### PR DESCRIPTION
Just a minor bug in the README example that the compiler complained about when making this into a demo for the RIOT examples.