### PR TITLE
morse: Add space patterns

### DIFF
--- a/src/patterns.rs
+++ b/src/patterns.rs
@@ -62,6 +62,12 @@ pub mod morse {
     pub const ERROR: Pattern = DOT.append(&DOT).append(&DOT).append(&DOT).append(&DOT).append(&DOT).append(&DOT).append(&DOT);
 
     pub const SOS: Pattern = S.append(&O).append(&S);
+    
+    /// 3 dits silence, but the dashes and dots of the letters all include one silent dit already
+    pub const LETTERSPACE: blinq::Pattern = blinq::Pattern::from_u32(0, 2);
+    /// 7 dits silence, but 3 are already in the preceding letter's LETTERSPACE, and 2 more are
+    /// deduced for the LETTERSPACE later added to this when treating a space as a character
+    pub const WORDSPACE: blinq::Pattern = blinq::Pattern::from_u32(0, 2);
 }
 
 pub mod blinks {


### PR DESCRIPTION
This adds the spaces needed to build words and sentences out of patterns.

---

It makes sense to have this in here, because (together with the comments) this allows users to build simple Morse messages without having to look up any timings.

The alternative to the letter spacing would be to append a letter space to all letters. That would likely not overflow the 32 bits, make composition a bit easier, and cut buffer sizes in half -- at the cost of altering the definitions in what might be considered a breaking change. (Then again, the example just puts the letters "HELLO" in the buffer in one go, so maybe it was intended to work like that -- if so, I can make a conflicting PR to that effect).