### PR TITLE
Use embedded-hal 1.0, release as 0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,4 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 heapless = "0.7.0"
-embedded-hal = "0.2.4"
+embedded-hal = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blinq"
-version = "0.2.0"
+version = "0.3.0"
 description = "An embedded-hal blinking queue"
 repository = "https://github.com/jamesmunns/blinq"
 authors = ["James Munns <james.munns@ferrous-systems.com>"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,7 @@
 
 #![cfg_attr(not(test), no_std)]
 
-use embedded_hal::digital::v2::OutputPin;
+use embedded_hal::digital::OutputPin;
 
 use heapless::spsc::Queue;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,19 +7,22 @@
 //!
 //! ```rust
 //! # use core::sync::atomic::{AtomicBool, Ordering};
-//! # use embedded_hal::digital::v2::OutputPin;
+//! # use embedded_hal::digital::{ErrorType, OutputPin};
 //! #
 //! # struct FakeGpio {
 //! #     state: &'static AtomicBool,
 //! # }
 //! #
+//! # impl ErrorType for FakeGpio {
+//! #     type Error = core::convert::Infallible;
+//! # }
+//! #
 //! # impl OutputPin for FakeGpio {
-//! #     type Error = ();
-//! #     fn set_low(&mut self) -> Result<(), ()> {
+//! #     fn set_low(&mut self) -> Result<(), Self::Error> {
 //! #         self.state.store(false, Ordering::SeqCst);
 //! #         Ok(())
 //! #     }
-//! #     fn set_high(&mut self) -> Result<(), ()> {
+//! #     fn set_high(&mut self) -> Result<(), Self::Error> {
 //! #         self.state.store(true, Ordering::SeqCst);
 //! #         Ok(())
 //! #     }
@@ -153,19 +156,22 @@ impl Pattern {
 ///
 /// ```rust
 /// # use core::sync::atomic::{AtomicBool, Ordering};
-/// # use embedded_hal::digital::v2::OutputPin;
+/// # use embedded_hal::digital::{ErrorType, OutputPin};
 /// #
 /// # struct FakeGpio {
 /// #     state: &'static AtomicBool,
 /// # }
 /// #
+/// # impl ErrorType for FakeGpio {
+/// #     type Error = core::convert::Infallible;
+/// # }
+/// #
 /// # impl OutputPin for FakeGpio {
-/// #     type Error = ();
-/// #     fn set_low(&mut self) -> Result<(), ()> {
+/// #     fn set_low(&mut self) -> Result<(), Self::Error> {
 /// #         self.state.store(false, Ordering::SeqCst);
 /// #         Ok(())
 /// #     }
-/// #     fn set_high(&mut self) -> Result<(), ()> {
+/// #     fn set_high(&mut self) -> Result<(), Self::Error> {
 /// #         self.state.store(true, Ordering::SeqCst);
 /// #         Ok(())
 /// #     }
@@ -346,6 +352,7 @@ where
 mod tests {
     use super::*;
     use crate::patterns::morse::SOS;
+    use embedded_hal::digital::ErrorType;
 
     use core::sync::atomic::{AtomicBool, Ordering};
 
@@ -353,13 +360,16 @@ mod tests {
         state: &'static AtomicBool,
     }
 
+    impl ErrorType for FakeGpio {
+        type Error = core::convert::Infallible;
+    }
+
     impl OutputPin for FakeGpio {
-        type Error = ();
-        fn set_low(&mut self) -> Result<(), ()> {
+        fn set_low(&mut self) -> Result<(), Self::Error> {
             self.state.store(false, Ordering::SeqCst);
             Ok(())
         }
-        fn set_high(&mut self) -> Result<(), ()> {
+        fn set_high(&mut self) -> Result<(), Self::Error> {
             self.state.store(true, Ordering::SeqCst);
             Ok(())
         }


### PR DESCRIPTION
Hardware abstractions have (OK: RIOT OS has) ceased to provide embedded-hal 0.2 implementations; a 0.3 of blinq can make it useful with it again.

[edit: I stand corrected on "have ceased to" in the concrete case given; nonetheless, it'd be a useful update]